### PR TITLE
Add application/*+json to supported media types

### DIFF
--- a/src/PartialResponse.AspNetCore.Mvc.Formatters.Json/Internal/MediaTypeHeaderValues.cs
+++ b/src/PartialResponse.AspNetCore.Mvc.Formatters.Json/Internal/MediaTypeHeaderValues.cs
@@ -8,6 +8,8 @@ namespace PartialResponse.AspNetCore.Mvc.Formatters.Json.Internal
     {
         public static readonly MediaTypeHeaderValue ApplicationJson = MediaTypeHeaderValue.Parse("application/json").CopyAsReadOnly();
 
+        public static readonly MediaTypeHeaderValue ApplicationWildcardJson = MediaTypeHeaderValue.Parse("application/*+json").CopyAsReadOnly();
+
         public static readonly MediaTypeHeaderValue TextJson = MediaTypeHeaderValue.Parse("text/json").CopyAsReadOnly();
     }
 }

--- a/src/PartialResponse.AspNetCore.Mvc.Formatters.Json/PartialJsonOutputFormatter.cs
+++ b/src/PartialResponse.AspNetCore.Mvc.Formatters.Json/PartialJsonOutputFormatter.cs
@@ -56,6 +56,7 @@ namespace PartialResponse.AspNetCore.Mvc.Formatters
             this.SupportedEncodings.Add(Encoding.UTF8);
             this.SupportedEncodings.Add(Encoding.Unicode);
             this.SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationJson);
+            this.SupportedMediaTypes.Add(MediaTypeHeaderValues.ApplicationWildcardJson);
             this.SupportedMediaTypes.Add(MediaTypeHeaderValues.TextJson);
         }
 


### PR DESCRIPTION
Matches the default of the stock JSON formatter.
Fixes an issue with the newly-added ProblemDetails behavior that wants to use media type `application/problem+json` (details [here](https://docs.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-2.2?view=aspnetcore-2.2)).